### PR TITLE
tslearn 0.6.3 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+
+upload_channels:
+  - sfe1ed40
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,3 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes
 
 upload_channels:
   - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py>311 or s390x]
+  skip: true  # [s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
@@ -54,6 +54,7 @@ test:
     - h5py
   commands:
     - pip check
+    # skipping tensorflow required tests, due to not having tensorflow.keras requirement
     - pytest -vv tslearn/tests {{ pytest_ignore }} -k "not ({{ pytest_skip }})"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py>312]
+  skip: true  # [py>311 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
@@ -52,8 +52,6 @@ test:
     - pip
     - pytest
     - h5py
-    - tensorflow
-    - keras
   commands:
     - pip check
     - pytest -vv tslearn/tests {{ pytest_ignore }} -k "not ({{ pytest_skip }})"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,12 +19,12 @@ requirements:
   build:
     - python
     - numpy
-    - setuptools
-    - wheel
   host:
     - python
     - pip
     - numpy {{ numpy }}
+    - setuptools
+    - wheel
   run:
     - python
     - {{ pin_compatible('numpy') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  #skip: true
+  skip: true  # [py>312]
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py>312 or s390x]
+  skip: true  # [py>311 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,7 @@ requirements:
     - scikit-learn
     - numba
     - joblib
-  run_constrained:
-    # tslearn's current keras is not compatible with recent tensorflow (keras 2 vs keras 3)
+    # tslearn's current keras is not compatible with recent tensorflow (keras 2 vs keras 3) 
     - tensorflow >=2.0,<2.16
 
 {% set pytest_ignore = '--ignore="tslearn/tests/test_estimators.py"' %}
@@ -62,7 +61,7 @@ test:
     - tslearn.piecewise
     - tslearn.preprocessing
     # requires tensorflow and keras
-    #- tslearn.shapelets
+    - tslearn.shapelets
     - tslearn.svm
     - tslearn.utils
   requires:
@@ -70,7 +69,11 @@ test:
     - pytest
     - h5py
   commands:
-    - pip check
+    # tensorflow 2.12.0 requires jax, which is not installed.
+    # tensorflow 2.12.0 requires libclang, which is not installed.
+    # tensorflow 2.12.0 has requirement wrapt<1.15,>=1.11.0, but you have wrapt 1.17.0.
+    # Can`t fix from this package
+    #- pip check
     # skipping tensorflow tests due to old tensorflow requirements
     - pytest -vv tslearn/tests {{ pytest_ignore }} -k "not ({{ pytest_skip }})"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "tslearn" %}
-{% set version = "0.5.3.2" %}
-{% set sha256 = "acf4015b07207ad6a645ddcc8eec04d8431716b24db66a745ab29fa22f772820" %}
+{% set version = "0.6.3" %}
 
 
 package:
@@ -8,27 +7,24 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: c855c0b784b42dc4c50f4eaf524ec7ed658037e86fc14af38ca3b66c75dd6adb
 
 build:
   number: 0
-  skip: true  # [py2k]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  #skip: true
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
-    - numpy                                  # [build_platform != target_platform]
-    - {{ compiler('c') }}
+    - python
+    - numpy
+    - setuptools
+    - wheel
   host:
     - python
     - pip
-    - cython
-    - numpy
+    - numpy {{ numpy }}
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -37,10 +33,30 @@ requirements:
     - numba
     - joblib
 
+{% set pytest_ignore = '--ignore="tslearn/tests/test_estimators.py"' %}
+{% set pytest_ignore = pytest_ignore + ' --ignore="tslearn/tests/test_serialize_models.py"' %}
+
+{% set pytest_skip = "test_masks" %}
+{% set pytest_skip = pytest_skip + " or test_shapelets" %}
+{% set pytest_skip = pytest_skip + " or test_shapelet_lengths" %}
+{% set pytest_skip = pytest_skip + " or test_series_lengths" %}
+
+
 test:
+  source_files:
+    - tslearn/tests
   imports:
     - tslearn
     - tslearn.metrics
+  requires:
+    - pip
+    - pytest
+    - h5py
+    - tensorflow
+    - keras
+  commands:
+    - pip check
+    - pytest -vv tslearn/tests {{ pytest_ignore }} -k "not ({{ pytest_skip }})"
 
 about:
   home: http://tslearn.readthedocs.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,23 @@ test:
   imports:
     - tslearn
     - tslearn.metrics
+    - tslearn.backend
+    - tslearn.barycenters
+    - tslearn.bases
+    - tslearn.clustering
+    - tslearn.datasets
+    - tslearn.early_classification
+    - tslearn.generators
+    - tslearn.hdftools
+    - tslearn.matrix_profile
+    - tslearn.neighbors
+    - tslearn.neural_network
+    - tslearn.piecewise
+    - tslearn.preprocessing
+    # requires tensorflow and keras
+    #- tslearn.shapelets
+    - tslearn.svm
+    - tslearn.utils
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,18 +16,16 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
-  build:
-    - python
-    - numpy
   host:
     - python
     - pip
-    - numpy {{ numpy }}
+    - numpy 2.0 # [py<313]
+    - numpy 2.1 # [py>=313]
     - setuptools
     - wheel
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy
     - scipy
     - scikit-learn
     - numba

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,12 @@ source:
 
 build:
   number: 0
-  skip: true  # [py>311 or s390x]
+  # On s390x tensorflow  does not exist (perhaps a typo or a missing channel).
+  skip: True  # [s390x]
+  # tensorflow and keros compatible versions is not avaliable from py312
+  skip: True  # [py>311]
+  # tensorflow on windows is avaliable only form py37 to py310
+  skip: True  # [win and py>310]
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,9 @@ requirements:
     - scikit-learn
     - numba
     - joblib
+  run_constrained:
+    # tslearn's current keras is not compatible with recent tensorflow (keras 2 vs keras 3)
+    - tensorflow >=2.0,<2.16
 
 {% set pytest_ignore = '--ignore="tslearn/tests/test_estimators.py"' %}
 {% set pytest_ignore = pytest_ignore + ' --ignore="tslearn/tests/test_serialize_models.py"' %}
@@ -38,7 +41,6 @@ requirements:
 {% set pytest_skip = pytest_skip + " or test_shapelets" %}
 {% set pytest_skip = pytest_skip + " or test_shapelet_lengths" %}
 {% set pytest_skip = pytest_skip + " or test_series_lengths" %}
-
 
 test:
   source_files:
@@ -52,7 +54,7 @@ test:
     - h5py
   commands:
     - pip check
-    # skipping tensorflow required tests, due to not having tensorflow.keras requirement
+    # skipping tensorflow tests due to old tensorflow requirements
     - pytest -vv tslearn/tests {{ pytest_ignore }} -k "not ({{ pytest_skip }})"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [s390x]
+  skip: true  # [py>312 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:


### PR DESCRIPTION
tslearn 0.6.3 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-6081]
- dev_url:        https://github.com/tslearn-team/tslearn/tree/v0.6.3
- conda_forge:    https://github.com/conda-forge/tslearn-feedstock
- pypi:           https://pypi.org/project/tslearn/0.6.3
- pypi inspector: https://inspector.pypi.io/project/tslearn/0.6.3

### Explanation of changes:

- feedstock added to aggregate
- some tests were requiring `tensorflow`, and `tensorflow.keras`. Skipped them due to having dep compatibility issues.


[PKG-6081]: https://anaconda.atlassian.net/browse/PKG-6081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ